### PR TITLE
240308_17_신예진

### DIFF
--- a/lib/240308_homework/Cleric.dart
+++ b/lib/240308_homework/Cleric.dart
@@ -1,0 +1,41 @@
+
+void main(){
+
+  //A
+  Cleric clericA = Cleric(name:'아서스',hp: 40,mp:5);
+  //B
+  Cleric clericB = Cleric(name:'아서스',hp: 35);
+  //C
+  Cleric clericC = Cleric(name:'아서스');
+  //D
+  Cleric clericD = Cleric(name:'아서스',mp:5);
+
+  print('clericA : ${clericA.hp},${clericA.mp}');
+  print('clericB : ${clericB.hp},${clericB.mp}');
+  print('clericC : ${clericC.hp},${clericC.mp}');
+  print('clericD : ${clericD.hp},${clericD.mp}');
+}
+
+class Cleric {
+  //왜 상수여야 하며, final은 안되는가?
+  //static에 항상 const가 있어야 하는것도 아니고 생성자에 귀속되는 값이 아니다.
+  //그러나 생성자에 hpMax 값을 필요로 한다.
+  //생성자는 runtime에 실행 된다. => default 값이 필요. 따라서 static const 로 선언해준다.
+
+  static const int hpMax = 50;
+  static const int mpMax = 10;
+
+  String name;
+  int hp = 50;
+  int mp = 10;
+
+  //A
+  // Cleric(this.name, this.hp, this.mp);
+  //B
+  // Cleric(this.name, this.hp,{this.mp = Cleric.mpMax});
+  //C
+  // Cleric(this.name, {this.hp = Cleric.hpMax, this.mp = Cleric.mpMax});
+  //D
+  Cleric({required this.name, this.hp = Cleric.hpMax, this.mp = Cleric.mpMax});
+
+}


### PR DESCRIPTION
refactor: modifying as named parameter

<details><summary>세부 내용</summary>
- Cleric 필드에 static 구문 추가
- Cleric class의 생성자를 named parameter로 변경
</details> 


<details><summary>자문자답</summary>
<br/> 

`static const int hpMax = 50;` 

Q. 이 부분은 왜 상수여야 하며, final 키워드는 안되는가? <br/>
A. 

1. static에 항상 const 키워드가 있어야 하는것도 아니고 static이 생성자에 귀속되는 값도 아니다.
2. 그러나 runtime에 실행되는 생성자에서 hpMax 값을 필요로 한다. 
3. runtime에 실행되기 위해서는 default 값이 필요하다. 

=> 따라서 const 키워드로 선언해준다.

</details> 
